### PR TITLE
Add _run_once to be consistent with asyncio

### DIFF
--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -423,7 +423,11 @@ cdef class Loop:
         self._stopping = 1
         if not self.handler_idle.running:
             self.handler_idle.start()
-
+    
+    def _run_once(self):
+        # Run an interation of the event loop
+        self._on_idle()
+        
     cdef __run(self, uv.uv_run_mode mode):
         # Although every UVHandle holds a reference to the loop,
         # we want to do everything to ensure that the loop will


### PR DESCRIPTION
Allows the user to manually run an iteration the event loop. Named to be consistent with https://github.com/python/cpython/blob/3.6/Lib/asyncio/base_events.py#L1338.

This allows you to "wait" for a future to complete within a sync function and is also useful for tests.